### PR TITLE
Added better transition error messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
 before_install:
   - gem install bundler --version '>= 1.2.2'
 script: "bundle exec rake test"

--- a/lib/state_manager/version.rb
+++ b/lib/state_manager/version.rb
@@ -1,3 +1,3 @@
 module StateManager
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
 end

--- a/test/transitions_test.rb
+++ b/test/transitions_test.rb
@@ -168,4 +168,26 @@ class TransitionsTest < Minitest::Test
     assert_equal :ban, @resource.state_manager.did_event
   end
 
+  def error_message_test(klass, state)
+    @resource.ban!
+    exp = "StateManager::#{klass}".constantize
+    begin
+      @resource.state_manager.transition_to(state)
+    rescue exp => e
+      assert_equal "Unable to transition from inactive.banned to #{state}", e.message
+    end
+  end
+
+  def test_invalid_event
+    error_message_test("InvalidEvent", "active.default")
+  end
+
+  def test_state_not_found
+    error_message_test("StateNotFound", "brodown")
+  end
+
+  def test_invalid_transition
+    error_message_test("InvalidTransition", "active")
+  end
+
 end


### PR DESCRIPTION
Previously error messages just included the state it was trying to transition to. This adds the current state to the message and makes it override-able by users in a method called `transition_error`