### PR TITLE
Remove LIKE clause from AR scope

### DIFF
--- a/lib/state_manager/state.rb
+++ b/lib/state_manager/state.rb
@@ -18,6 +18,15 @@ module StateManager
         self.states = source.states.dup
         self.events = source.events.dup
       end
+
+      def descendant_names
+        res = []
+        states.each do |state, specification_klass|
+          res << state
+          res.concat specification_klass.specification.descendant_names.map{|s| "#{state}.#{s}"}
+        end
+        res
+      end
     end
 
     class_attribute :specification
@@ -140,7 +149,7 @@ module StateManager
     end
 
     protected
-    
+
     attr_writer :name, :states, :parent_state
 
     def method_missing(name, *args, &block)

--- a/test/adapters/active_record_test.rb
+++ b/test/adapters/active_record_test.rb
@@ -25,7 +25,7 @@ class ActiveRecordTest < Minitest::Test
     state :active
     state :rejected
     state :mutated
-    
+
     attr_accessor :unsubmitted_entered_count
     attr_accessor :unsubmitted_enter_committed_count
     attr_accessor :unsubmitted_exit_committed_count
@@ -51,9 +51,9 @@ class ActiveRecordTest < Minitest::Test
     def did_transition(*args)
       self.after_callbacks_called = true
     end
-    
+
     class Unsubmitted
-      
+
       def entered
         state_manager.unsubmitted_entered_count += 1
       end
@@ -65,11 +65,11 @@ class ActiveRecordTest < Minitest::Test
       def exit_committed
         state_manager.unsubmitted_exit_committed_count += 1
       end
-      
+
     end
-    
+
     class Active
-      
+
       def entered
         state_manager.active_entered_count += 1
       end
@@ -81,7 +81,7 @@ class ActiveRecordTest < Minitest::Test
       def exit_committed
         state_manager.active_exit_committed_count += 1
       end
-      
+
     end
 
     class Mutated
@@ -92,7 +92,7 @@ class ActiveRecordTest < Minitest::Test
       end
 
     end
-    
+
   end
 
   class Post < ActiveRecord::Base
@@ -195,8 +195,8 @@ class ActiveRecordTest < Minitest::Test
 
     # +1 from setup
     assert_equal 1, Post.unsubmitted.count
-    # +2 from setup
-    assert_equal 8, Post.submitted.count
+    # +1 from setup (one is in a bad state)
+    assert_equal 7, Post.submitted.count
     assert_equal 4, Post.active.count
     assert_equal 0, Post.rejected.count
   end
@@ -217,7 +217,7 @@ class ActiveRecordTest < Minitest::Test
       @resource.state_manager.send_event :review
     end
   end
-  
+
   def test_commit_callbacks
     @resource = Post.find(1)
     assert_state 'unsubmitted'
@@ -242,7 +242,7 @@ class ActiveRecordTest < Minitest::Test
     assert_equal 1, @resource.state_manager.unsubmitted_exit_committed_count
     assert_equal 1, @resource.state_manager.active_enter_committed_count
   end
-  
+
   def test_commit_callbacks_on_create
     Post.transaction do
       @resource = Post.new
@@ -254,7 +254,7 @@ class ActiveRecordTest < Minitest::Test
     end
     assert_equal 1, @resource.state_manager.unsubmitted_enter_committed_count
   end
-  
+
   def test_commit_callbacks_on_different_initial_state
     Post.transaction do
       @resource = Post.new(:state => 'active')


### PR DESCRIPTION
This changes the generated ActiveRecord scopes to use an `IN` clause rather than a `LIKE`. This also changes the behavior slightly in that the scope will exclude substates that are invalid (whereas the previous behavior included them).